### PR TITLE
Fix out-of-bounds string access

### DIFF
--- a/src/clj_async_profiler/post_processing.clj
+++ b/src/clj_async_profiler/post_processing.clj
@@ -45,7 +45,7 @@
                                       ;; no special characters munged in the
                                       ;; frame, take a faster path.
                                       next-char-idx (inc uscore)]
-                                  (if (and (<= next-char-idx (.length ^String new-frame))
+                                  (if (and (< next-char-idx (.length ^String new-frame))
                                            (Character/isUpperCase (.charAt frame next-char-idx)))
                                     (Compiler/demunge new-frame)
                                     (-> ^String new-frame


### PR DESCRIPTION
Use `charAt` only if `next-char-idx` is strictly less than length of the string(`frame`). Otherwise, it results in a out-of-bounds array access if the last character in `frame` is `_`.