### PR TITLE
Add custom title support

### DIFF
--- a/src/clj_async_profiler/core.clj
+++ b/src/clj_async_profiler/core.clj
@@ -125,12 +125,13 @@
 
 (defn run-flamegraph-script
   "Run Flamegraph script on the provided stacks file, rendering the SVG result."
-  [in-stacks-file out-svg-file {:keys [min-width reverse? icicle? width height]
+  [in-stacks-file out-svg-file {:keys [min-width reverse? icicle? width height title]
                                 :or {icicle? reverse?}}]
   (let [args (flatten ["perl" (flamegraph-script) "--colors=clojure"
                        (if min-width [(str "--minwidth=" min-width)] [])
                        (if width [(str "--width=" width)] [])
                        (if height [(str "--height=" height)] [])
+                       (if title [(str "--title=" title)] [])
                        (if reverse? ["--reverse"] [])
                        (if icicle? ["--inverted"] [])
                        (str in-stacks-file)])
@@ -299,10 +300,11 @@
                browser (default: nil, recommended: 1-5)
   :width     - width of the generated flamegraph (default: 1200px, recommended to change for big screens)
   :height    - height of the generated flamegraph
-  :reverse? - if true, generate the reverse flamegraph which grows from callees
-              up to callers (default: false)
-  :icicle? - if true, invert the flamegraph upside down (default: false for
-             regular flamegraph, true for reverse)"
+  :title     - title of the generated flamegraph (default: \"Flame Graph\")
+  :reverse?  - if true, generate the reverse flamegraph which grows from callees
+               up to callers (default: false)
+  :icicle?   - if true, invert the flamegraph upside down (default: false for
+               regular flamegraph, true for reverse)"
   ([] (stop {}))
   ([options]
    (let [pid (or (:pid options) (get-self-pid))


### PR DESCRIPTION
This uses the existing support for `--title` to pass in an optional
string which will be placed at the top center of the flame graph.

A good use case for this is timestamping, categorizing, or otherwise
distinguishing one flame graph from another.

### Example
![custom-title](https://user-images.githubusercontent.com/1057635/95024291-ed0d3b00-0636-11eb-800f-c90f361cc45c.png)
