### PR TITLE
select output dir via ENV variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ Also check out this video from London Clojurians meetup:
 
 [![Clojure Goes Brrr: a quest for performance](http://img.youtube.com/vi/s3mjVAMNVrA/0.jpg)](http://www.youtube.com/watch?v=s3mjVAMNVrA "Clojure Goes Brrr: a quest for performance")
 
+### Output directory
+
+To not store the potentially large output files in `/tmp`, you can instead set a custom directory using the Java property `clj-async-profiler.output-dir`:
+
+`-Dclj-async-profiler.output-dir=./data`
+
+This is helpful in some cases where the boot drive is kept intentionally small, and you mount large external disks for primary use (like Fly.io).
+
 ### Tuning for better accuracy
 
 From [async-profiler

--- a/src/clj_async_profiler/core.clj
+++ b/src/clj_async_profiler/core.clj
@@ -17,7 +17,8 @@
 ;;; Temp file machinery
 
 (defonce ^:private temp-directory
-  (let [root (io/file "/tmp" "clj-async-profiler")]
+  (let [output-dir  (or (System/getProperty "clj-async-profiler.output-dir") "/tmp")
+        root (io/file output-dir "clj-async-profiler")]
     (.mkdirs (io/file root "results"))
     (.mkdirs (io/file root "internal"))
     root))


### PR DESCRIPTION
#27

Let me know if you require tests for this to be accepted. Have tested it locally with `CLCLJ_ASYNC_PROFILER_OUTPUT_DIR="./data" ./start-app-cmd` and it uses the `/data` dir fine.