### PR TITLE
Add custom tooltip

### DIFF
--- a/res/flamegraph-rendering/script.js
+++ b/res/flamegraph-rendering/script.js
@@ -6,6 +6,7 @@
 const canvas = document.getElementById('canvas');
 const c = canvas.getContext('2d');
 const hl = document.getElementById('hl');
+const tooltip = document.getElementById('tooltip');
 const status = document.getElementById('status');
 const matchContainer = document.getElementById('match');
 const transformFilterTemplate = document.getElementById('transformFilterTemplate');
@@ -541,6 +542,39 @@ function findFrame(frames, x) {
   return null;
 }
 
+function showTooltip(e) {
+  tooltip.hidden = false;
+
+  var cursor_x  = e.clientX + window.pageXOffset;
+  var cursor_y  = e.clientY + window.pageYOffset;
+
+  let tooltip_w = tooltip.clientWidth;
+  let tooltip_h = tooltip.clientHeight;
+
+  var tooltip_x = cursor_x;
+  var tooltip_y = cursor_y + 22;
+
+  let box_width  = canvas.clientWidth  - 20;
+  let box_height = canvas.clientHeight - 20;
+
+
+  if (cursor_x + tooltip_w > box_width) {
+    let overflow_x = cursor_x + tooltip_w - box_width;
+    tooltip_x = cursor_x - overflow_x;
+  }
+
+  if (cursor_y + tooltip_h > box_height) {
+    tooltip_y = cursor_y - tooltip_h - 10;
+  }
+
+  tooltip.style.left = tooltip_x;
+  tooltip.style.top  = tooltip_y;
+}
+
+function hideTooltip() {
+  tooltip.hidden = true;
+}
+
 canvas.onmousemove = function() {
   const h = Math.floor((reverseGraph ? event.offsetY : (canvasHeight - event.offsetY)) / 16);
   if (h >= 0 && h < levels.length) {
@@ -554,10 +588,10 @@ canvas.onmousemove = function() {
       if (isDiffgraph) {
         var rel_change = (f.total_samples_a == 0) ? 1.0 : f.total_delta / f.total_samples_a;
         var total_change = f.total_delta / tree.total_samples_a;
-        canvas.title = `${f.title}\n(${samples(f.total_delta, true)}, ${ratioToPct(rel_change)} self, ${ratioToPct(total_change)} total)`;
+        tooltip.innerText = `${f.title}\n(${samples(f.total_delta, true)}, ${ratioToPct(rel_change)} self, ${ratioToPct(total_change)} total)`;
         // , self_samples_a: ${f.self_samples_a}, self_samples_b: ${f.self_samples_b},  self_delta: ${f.self_delta},  total_samples_a: ${f.total_samples_a},  total_samples_b: ${f.total_samples_b}, total_delta: ${f.total_delta})`;
       } else
-        canvas.title = f.title + '\n(' + samples(f.width) + ', ' + pct(f.width, levels[0][0].width) + '%)';
+        tooltip.innerText = f.title + '\n(' + samples(f.width) + ', ' + pct(f.width, levels[0][0].width) + '%)';
       canvas.style.cursor = 'pointer';
       canvas.onclick = function() {
         if (f != currentRootFrame) {
@@ -565,7 +599,8 @@ canvas.onmousemove = function() {
           canvas.onmousemove();
         }
       };
-      status.textContent = 'Function: ' + canvas.title;
+      showTooltip(event);
+      status.textContent = 'Function: ' + tooltip.innerText;
       return;
     }
   }
@@ -575,9 +610,9 @@ canvas.onmousemove = function() {
 canvas.onmouseout = function() {
   hl.style.display = 'none';
   status.textContent = '\xa0';
-  canvas.title = '';
   canvas.style.cursor = '';
   canvas.onclick = '';
+  hideTooltip();
 }
 
 function samples(n, add_plus) {

--- a/res/flamegraph-rendering/template.html
+++ b/res/flamegraph-rendering/template.html
@@ -8,7 +8,7 @@
       #hl span {padding: 0 3px 0 3px}
       #status {overflow: hidden; white-space: nowrap}
       #match {overflow: hidden; white-space: nowrap; display: none; float: right; text-align: right}
-      * {box-sizing:border-box,margin:.25em 0}
+      #tooltip {z-index: 9999; border-radius: 2px; padding: 2px 5px 2px 5px; position: absolute; background: white; font-size: 13px; opacity: 0.85; border: 1px solid #e9e9e9; box-shadow: rgba(0, 0, 0, 0.1) 0px 5px 15px 0px; white-space: nowrap;}      * {box-sizing:border-box,margin:.25em 0}
       .col{display:table-cell}
       .col-1{width:5%}
       .col-2{width:15%}
@@ -31,6 +31,7 @@
       <div class="row">
         <div class="graphCol">
           <canvas id='canvas' style='width: 100%;'></canvas>
+          <div id='tooltip' hidden></div>
           <div id='box'><div id='hl'><span></span></div></div>
           <p id='match'>Matched: <span id='matchedLabel'></span></p>
           <p id='status'>&nbsp;</p>


### PR DESCRIPTION
It's inconvenient to read the names of small frames since the default tooltip appears only after a certain time (2-3 seconds).

This pull request adds a custom tooltip that appears instantly

<img width="291" alt="image" src="https://github.com/clojure-goes-fast/clj-async-profiler/assets/43318093/1f5beba3-4f59-4578-bb5e-22f6e20ff0a6">
