### PR TITLE
Print what port the ui server started on

### DIFF
--- a/src/clj_async_profiler/ui.clj
+++ b/src/clj_async_profiler/ui.clj
@@ -106,5 +106,7 @@ a { text-decoration: none; }
   "Starts the profiler web UI with the local directory `dir` as its root."
   [host port dir]
   (stop-server)
-  (println "Starting server on port" port)
-  (reset! current-server (wwws/start-server #(handler % dir) host port)))
+  (let [server (reset! current-server
+                       (wwws/start-server #(handler % dir) host port))]
+    (println "Started server on port" (wwws/get-port server))
+    server))

--- a/src/clj_async_profiler/wwws.clj
+++ b/src/clj_async_profiler/wwws.clj
@@ -85,6 +85,9 @@
     (.setExecutor nil)
     (.start)))
 
+(defn get-port [^HttpServer server]
+  (some-> server .getAddress .getPort))
+
 (defn stop-server [^HttpServer server]
   (.stop server 0))
 

--- a/test/clj_async_profiler/core_test.clj
+++ b/test/clj_async_profiler/core_test.clj
@@ -1,5 +1,6 @@
 (ns clj-async-profiler.core-test
   (:require [clj-async-profiler.core :as sut]
+            [clj-async-profiler.wwws :as wwws]
             [clojure.test :refer :all])
   (:import java.net.URL))
 
@@ -25,6 +26,9 @@
 (deftest web-ui-test
   (sut/serve-ui 8085)
   (is (= 200 (curl-ui 8085)))
+
+  (let [port (wwws/get-port (sut/serve-ui 0))]
+    (is (= 200 (curl-ui port))))
 
   (sut/serve-files 8086)
   (is (= 200 (curl-ui 8086))))


### PR DESCRIPTION
Underlying stack supports assigning a random port when the specified one is 0.
Prior to this change the code only printed `Starting server on port 0` so it wasn't immediately clear where the UI could be accessed.